### PR TITLE
added missing fields

### DIFF
--- a/AdaptiveProjectedGuidanceExtension.cs
+++ b/AdaptiveProjectedGuidanceExtension.cs
@@ -24,106 +24,65 @@ public class AdaptiveProjectedGuidanceExtension : Extension
     public override void OnInit()
     {
         base.OnInit();
-
+        
         // Add the JS file, which manages the install buttons for the comfy nodes
         ScriptFiles.Add("assets/apg.js");
 
         // Define required nodes
         ComfyUIBackendExtension.NodeToFeatureMap["APG_ImYourCFGNow"] = FeatureId;
-
+        
         // Add required custom node as installable feature
-        InstallableFeatures.RegisterInstallableFeature(
-            new(
-                "APG_ImYourCFGNow",
-                FeatureId,
-                "https://github.com/MythicalChu/ComfyUI-APG_ImYourCFGNow",
-                "MythicalChu",
-                "This will install the APG_ImYourCFGNow ComfyUI node developed by MythicalChu.\nDo you wish to install?"
-            )
-        );
-
+        InstallableFeatures.RegisterInstallableFeature(new("APG_ImYourCFGNow", FeatureId, "https://github.com/MythicalChu/ComfyUI-APG_ImYourCFGNow", "MythicalChu", "This will install the APG_ImYourCFGNow ComfyUI node developed by MythicalChu.\nDo you wish to install?"));        
+        
         // Prevents install button from being shown during backend load if it looks like it was installed
         // it will appear if the backend loads and the backend reports it's not installed
-        if (
-            Directory.Exists(
-                Utilities.CombinePathWithAbsolute(
-                    Environment.CurrentDirectory,
-                    $"{ComfyUIBackendExtension.Folder}/DLNodes/APG_ImYourCFGNow"
-                )
-            )
-        )
+        if (Directory.Exists(Utilities.CombinePathWithAbsolute(Environment.CurrentDirectory, $"{ComfyUIBackendExtension.Folder}/DLNodes/APG_ImYourCFGNow")))
         {
             ComfyUIBackendExtension.FeaturesSupported.UnionWith([FeatureId]);
             ComfyUIBackendExtension.FeaturesDiscardIfNotFound.UnionWith([FeatureId]);
         }
 
-        T2IParamGroup paramGroup = new(
-            "Adaptive Projected Guidance",
-            Toggles: true,
-            Open: false,
-            IsAdvanced: false,
-            OrderPriority: 9
-        );
+        T2IParamGroup paramGroup = new("Adaptive Projected Guidance", Toggles: true, Open: false, IsAdvanced: false, OrderPriority: 9);
         int orderCounter = 0;
-        Momentum = T2IParamTypes.Register<double>(
-            new(
-                $"{Prefix}Momentum",
-                "Use this to control how saturated/burned your images are",
-                "0.5",
-                Min: -1.5,
-                Max: 1,
-                Step: 0.05,
-                ViewType: ParamViewType.SLIDER,
-                Group: paramGroup,
-                FeatureFlag: FeatureId,
-                OrderPriority: orderCounter++
-            )
-        );
-        AdaptiveMomentum = T2IParamTypes.Register<double>(
-            new(
-                $"{Prefix}Adaptive Momentum",
-                "Gradually brings momentum towards 0 every step"
-                    + "\n0 = No change to momentum"
-                    + "\n0.18 = Momentum will reach 0 roughly around the last step. This can help to dramatically lower glitches/noise, specially on lower steps or higher CFG values. This is the default value"
-                    + "\n0.19 = Momentum will reach 0 roughly around half the steps",
-                "0.18",
-                Min: 0,
-                Max: 1,
-                Step: 0.001,
-                ViewType: ParamViewType.SLIDER,
-                Group: paramGroup,
-                FeatureFlag: FeatureId,
-                OrderPriority: orderCounter++
-            )
-        );
-        NormThreshold = T2IParamTypes.Register<double>(
-            new(
-                $"{Prefix}Norm Threshold",
-                "",
-                "15",
-                Min: 0,
-                Max: 50,
-                Step: 0.5,
-                ViewType: ParamViewType.SLIDER,
-                Group: paramGroup,
-                FeatureFlag: FeatureId,
-                OrderPriority: orderCounter++
-            )
-        );
-        Eta = T2IParamTypes.Register<double>(
-            new(
-                $"{Prefix}Eta",
-                "",
-                "1",
-                Min: 0,
-                Max: 1,
-                Step: 0.1,
-                ViewType: ParamViewType.SLIDER,
-                Group: paramGroup,
-                FeatureFlag: FeatureId,
-                OrderPriority: orderCounter++
-            )
-        );
+        Momentum = T2IParamTypes.Register<double>(new($"{Prefix}Momentum",
+            "Use this to control how saturated/burned your images are",
+            "0.5",
+            Min: -1.5, Max: 1, Step: 0.05,
+            ViewType: ParamViewType.SLIDER,
+            Group: paramGroup,
+            FeatureFlag: FeatureId,
+            OrderPriority: orderCounter++
+        ));
+        AdaptiveMomentum = T2IParamTypes.Register<double>(new($"{Prefix}Adaptive Momentum",
+            "Gradually brings momentum towards 0 every step" +
+            "\n0 = No change to momentum" +
+            "\n0.18 = Momentum will reach 0 roughly around the last step. This can help to dramatically lower glitches/noise, specially on lower steps or higher CFG values. This is the default value" +
+            "\n0.19 = Momentum will reach 0 roughly around half the steps",
+            "0.18",
+            Min: 0, Max: 1, Step: 0.001,
+            ViewType: ParamViewType.SLIDER,
+            Group: paramGroup,
+            FeatureFlag: FeatureId,
+            OrderPriority: orderCounter++
+        ));
+        NormThreshold = T2IParamTypes.Register<double>(new($"{Prefix}Norm Threshold",
+            "",
+            "15",
+            Min: 0, Max: 50, Step: 0.5,
+            ViewType: ParamViewType.SLIDER,
+            Group: paramGroup,
+            FeatureFlag: FeatureId,
+            OrderPriority: orderCounter++
+        ));
+        Eta = T2IParamTypes.Register<double>(new($"{Prefix}Eta",
+            "",
+            "1",
+            Min: 0, Max: 1, Step: 0.1,
+            ViewType: ParamViewType.SLIDER,
+            Group: paramGroup,
+            FeatureFlag: FeatureId,
+            OrderPriority: orderCounter++
+        ));
         GuidanceSigmaStart = T2IParamTypes.Register<double>(
             new(
                 $"{Prefix}Guidance Sigma Start",
@@ -162,38 +121,30 @@ public class AdaptiveProjectedGuidanceExtension : Extension
                 OrderPriority: orderCounter++
             )
         );
-        WorkflowGenerator.AddModelGenStep(
-            g =>
+        WorkflowGenerator.AddModelGenStep(g =>
+        {
+            // Required param
+            if (!g.UserInput.TryGet(Momentum, out var momentum))
+                return;
+            
+            if (!g.Features.Contains(FeatureId))
+                throw new SwarmUserErrorException("AdaptiveProjectedGuidance parameters specified, but 'APG_ImYourCFGNow' feature isn't installed");
+
+            string nodeId = g.CreateNode("APG_ImYourCFGNow", new JObject
             {
-                // Required param
-                if (!g.UserInput.TryGet(Momentum, out var momentum))
-                    return;
-
-                if (!g.Features.Contains(FeatureId))
-                    throw new SwarmUserErrorException(
-                        "AdaptiveProjectedGuidance parameters specified, but 'APG_ImYourCFGNow' feature isn't installed"
-                    );
-
-                string nodeId = g.CreateNode(
-                    "APG_ImYourCFGNow",
-                    new JObject
-                    {
-                        ["model"] = g.LoadingModel,
-                        ["momentum"] = momentum,
-                        ["adaptive_momentum"] = g.UserInput.Get(AdaptiveMomentum),
-                        ["norm_threshold"] = g.UserInput.Get(NormThreshold),
-                        ["eta"] = g.UserInput.Get(Eta),
-                        ["guidance_sigma_start"] = g.UserInput.Get(GuidanceSigmaStart),
-                        ["guidance_sigma_end"] = g.UserInput.Get(GuidanceSigmaEnd),
-                        ["guidance_limiter"] = g.UserInput.Get(GuidanceLimiter),
-                        ["print_data"] = false,
-                    }
-                );
-
-                g.FinalModel = [nodeId, 0];
-                g.LoadingModel = [nodeId, 0];
-            },
-            -13
-        );
+                ["model"] = g.LoadingModel,
+                ["momentum"] = momentum,
+                ["adaptive_momentum"] = g.UserInput.Get(AdaptiveMomentum),
+                ["norm_threshold"] = g.UserInput.Get(NormThreshold),
+                ["eta"] = g.UserInput.Get(Eta),
+                ["guidance_sigma_start"] = g.UserInput.Get(GuidanceSigmaStart),
+                ["guidance_sigma_end"] = g.UserInput.Get(GuidanceSigmaEnd),
+                ["guidance_limiter"] = g.UserInput.Get(GuidanceLimiter),
+                ["print_data"] = false,
+            });
+            
+            g.FinalModel = [nodeId, 0];
+            g.LoadingModel = [nodeId, 0];
+        }, -13);
     }
 }

--- a/AdaptiveProjectedGuidanceExtension.cs
+++ b/AdaptiveProjectedGuidanceExtension.cs
@@ -83,6 +83,16 @@ public class AdaptiveProjectedGuidanceExtension : Extension
             FeatureFlag: FeatureId,
             OrderPriority: orderCounter++
         ));
+        GuidanceLimiter = T2IParamTypes.Register<bool>(
+            new(
+                $"{Prefix}Guidance Limiter",
+                "Drops the cfg (also, APG's functions) outside the specified range (ideally at the early steps and the later ones) improving variability and combating oversaturation",
+                "false",
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
         GuidanceSigmaStart = T2IParamTypes.Register<double>(
             new(
                 $"{Prefix}Guidance Sigma Start",
@@ -106,16 +116,6 @@ public class AdaptiveProjectedGuidanceExtension : Extension
                 Max: 10000,
                 Step: 0.01,
                 ViewType: ParamViewType.SLIDER,
-                Group: paramGroup,
-                FeatureFlag: FeatureId,
-                OrderPriority: orderCounter++
-            )
-        );
-        GuidanceLimiter = T2IParamTypes.Register<bool>(
-            new(
-                $"{Prefix}Guidance Limiter",
-                "",
-                "false",
                 Group: paramGroup,
                 FeatureFlag: FeatureId,
                 OrderPriority: orderCounter++

--- a/AdaptiveProjectedGuidanceExtension.cs
+++ b/AdaptiveProjectedGuidanceExtension.cs
@@ -15,91 +15,185 @@ public class AdaptiveProjectedGuidanceExtension : Extension
     public T2IRegisteredParam<double> Momentum,
         AdaptiveMomentum,
         NormThreshold,
-        Eta;
+        Eta,
+        GuidanceSigmaStart,
+        GuidanceSigmaEnd;
+
+    public T2IRegisteredParam<bool> GuidanceLimiter;
 
     public override void OnInit()
     {
         base.OnInit();
-        
+
         // Add the JS file, which manages the install buttons for the comfy nodes
         ScriptFiles.Add("assets/apg.js");
 
         // Define required nodes
         ComfyUIBackendExtension.NodeToFeatureMap["APG_ImYourCFGNow"] = FeatureId;
-        
+
         // Add required custom node as installable feature
-        InstallableFeatures.RegisterInstallableFeature(new("APG_ImYourCFGNow", FeatureId, "https://github.com/MythicalChu/ComfyUI-APG_ImYourCFGNow", "MythicalChu", "This will install the APG_ImYourCFGNow ComfyUI node developed by MythicalChu.\nDo you wish to install?"));        
-        
+        InstallableFeatures.RegisterInstallableFeature(
+            new(
+                "APG_ImYourCFGNow",
+                FeatureId,
+                "https://github.com/MythicalChu/ComfyUI-APG_ImYourCFGNow",
+                "MythicalChu",
+                "This will install the APG_ImYourCFGNow ComfyUI node developed by MythicalChu.\nDo you wish to install?"
+            )
+        );
+
         // Prevents install button from being shown during backend load if it looks like it was installed
         // it will appear if the backend loads and the backend reports it's not installed
-        if (Directory.Exists(Utilities.CombinePathWithAbsolute(Environment.CurrentDirectory, $"{ComfyUIBackendExtension.Folder}/DLNodes/APG_ImYourCFGNow")))
+        if (
+            Directory.Exists(
+                Utilities.CombinePathWithAbsolute(
+                    Environment.CurrentDirectory,
+                    $"{ComfyUIBackendExtension.Folder}/DLNodes/APG_ImYourCFGNow"
+                )
+            )
+        )
         {
             ComfyUIBackendExtension.FeaturesSupported.UnionWith([FeatureId]);
             ComfyUIBackendExtension.FeaturesDiscardIfNotFound.UnionWith([FeatureId]);
         }
 
-        T2IParamGroup paramGroup = new("Adaptive Projected Guidance", Toggles: true, Open: false, IsAdvanced: false, OrderPriority: 9);
+        T2IParamGroup paramGroup = new(
+            "Adaptive Projected Guidance",
+            Toggles: true,
+            Open: false,
+            IsAdvanced: false,
+            OrderPriority: 9
+        );
         int orderCounter = 0;
-        Momentum = T2IParamTypes.Register<double>(new($"{Prefix}Momentum",
-            "Use this to control how saturated/burned your images are",
-            "0.5",
-            Min: -1.5, Max: 1, Step: 0.05,
-            ViewType: ParamViewType.SLIDER,
-            Group: paramGroup,
-            FeatureFlag: FeatureId,
-            OrderPriority: orderCounter++
-        ));
-        AdaptiveMomentum = T2IParamTypes.Register<double>(new($"{Prefix}Adaptive Momentum",
-            "Gradually brings momentum towards 0 every step" +
-            "\n0 = No change to momentum" +
-            "\n0.18 = Momentum will reach 0 roughly around the last step. This can help to dramatically lower glitches/noise, specially on lower steps or higher CFG values. This is the default value" +
-            "\n0.19 = Momentum will reach 0 roughly around half the steps",
-            "0.18",
-            Min: 0, Max: 1, Step: 0.001,
-            ViewType: ParamViewType.SLIDER,
-            Group: paramGroup,
-            FeatureFlag: FeatureId,
-            OrderPriority: orderCounter++
-        ));
-        NormThreshold = T2IParamTypes.Register<double>(new($"{Prefix}Norm Threshold",
-            "",
-            "15",
-            Min: 0, Max: 50, Step: 0.5,
-            ViewType: ParamViewType.SLIDER,
-            Group: paramGroup,
-            FeatureFlag: FeatureId,
-            OrderPriority: orderCounter++
-        ));
-        Eta = T2IParamTypes.Register<double>(new($"{Prefix}Eta",
-            "",
-            "1",
-            Min: 0, Max: 1, Step: 0.1,
-            ViewType: ParamViewType.SLIDER,
-            Group: paramGroup,
-            FeatureFlag: FeatureId,
-            OrderPriority: orderCounter++
-        ));
-        WorkflowGenerator.AddModelGenStep(g =>
-        {
-            // Required param
-            if (!g.UserInput.TryGet(Momentum, out var momentum))
-                return;
-            
-            if (!g.Features.Contains(FeatureId))
-                throw new SwarmUserErrorException("AdaptiveProjectedGuidance parameters specified, but 'APG_ImYourCFGNow' feature isn't installed");
-
-            string nodeId = g.CreateNode("APG_ImYourCFGNow", new JObject
+        Momentum = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Momentum",
+                "Use this to control how saturated/burned your images are",
+                "0.5",
+                Min: -1.5,
+                Max: 1,
+                Step: 0.05,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        AdaptiveMomentum = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Adaptive Momentum",
+                "Gradually brings momentum towards 0 every step"
+                    + "\n0 = No change to momentum"
+                    + "\n0.18 = Momentum will reach 0 roughly around the last step. This can help to dramatically lower glitches/noise, specially on lower steps or higher CFG values. This is the default value"
+                    + "\n0.19 = Momentum will reach 0 roughly around half the steps",
+                "0.18",
+                Min: 0,
+                Max: 1,
+                Step: 0.001,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        NormThreshold = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Norm Threshold",
+                "",
+                "15",
+                Min: 0,
+                Max: 50,
+                Step: 0.5,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        Eta = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Eta",
+                "",
+                "1",
+                Min: 0,
+                Max: 1,
+                Step: 0.1,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        GuidanceSigmaStart = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Guidance Sigma Start",
+                "",
+                "5.42",
+                Min: -1,
+                Max: 10000,
+                Step: 0.01,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        GuidanceSigmaEnd = T2IParamTypes.Register<double>(
+            new(
+                $"{Prefix}Guidance Sigma End",
+                "",
+                "0.28",
+                Min: -1,
+                Max: 10000,
+                Step: 0.01,
+                ViewType: ParamViewType.SLIDER,
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        GuidanceLimiter = T2IParamTypes.Register<bool>(
+            new(
+                $"{Prefix}Guidance Limiter",
+                "",
+                "false",
+                Group: paramGroup,
+                FeatureFlag: FeatureId,
+                OrderPriority: orderCounter++
+            )
+        );
+        WorkflowGenerator.AddModelGenStep(
+            g =>
             {
-                ["model"] = g.LoadingModel,
-                ["momentum"] = momentum,
-                ["adaptive_momentum"] = g.UserInput.Get(AdaptiveMomentum),
-                ["norm_threshold"] = g.UserInput.Get(NormThreshold),
-                ["eta"] = g.UserInput.Get(Eta),
-                ["print_data"] = false,
-            });
-            
-            g.FinalModel = [nodeId, 0];
-            g.LoadingModel = [nodeId, 0];
-        }, -13);
+                // Required param
+                if (!g.UserInput.TryGet(Momentum, out var momentum))
+                    return;
+
+                if (!g.Features.Contains(FeatureId))
+                    throw new SwarmUserErrorException(
+                        "AdaptiveProjectedGuidance parameters specified, but 'APG_ImYourCFGNow' feature isn't installed"
+                    );
+
+                string nodeId = g.CreateNode(
+                    "APG_ImYourCFGNow",
+                    new JObject
+                    {
+                        ["model"] = g.LoadingModel,
+                        ["momentum"] = momentum,
+                        ["adaptive_momentum"] = g.UserInput.Get(AdaptiveMomentum),
+                        ["norm_threshold"] = g.UserInput.Get(NormThreshold),
+                        ["eta"] = g.UserInput.Get(Eta),
+                        ["guidance_sigma_start"] = g.UserInput.Get(GuidanceSigmaStart),
+                        ["guidance_sigma_end"] = g.UserInput.Get(GuidanceSigmaEnd),
+                        ["guidance_limiter"] = g.UserInput.Get(GuidanceLimiter),
+                        ["print_data"] = false,
+                    }
+                );
+
+                g.FinalModel = [nodeId, 0];
+                g.LoadingModel = [nodeId, 0];
+            },
+            -13
+        );
     }
 }


### PR DESCRIPTION
there were some extra fields added which prevents new users from being able to use this extension. The fields are:
* guidance_sigma_start
* guidance_sigma_end
* guidance_limiter
* print_data

print_data is automatically set to False at all times, this is because it doesn't output anything valuable, and just clutters the logs. The rest can be generally kept at the default values, as they are plenty usable as is.

screenshot:
![waterfox_ENgsADPBWk](https://github.com/user-attachments/assets/fa28a01b-5de4-494e-92bf-0bf760fa20b5)
